### PR TITLE
Feat add split and merge tokens rules in cql rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ output_test.txt
 maxmatch_output.py
 test_rdr.py
 test_split_merge_function.py
+output.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test_output_similarity.py
 output_test.txt
 maxmatch_output.py
 test_rdr.py
+test_split_merge_function.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/word_segmentation_rules_generator/rdr_2_cql/split_merge_syls.py
+++ b/src/word_segmentation_rules_generator/rdr_2_cql/split_merge_syls.py
@@ -1,6 +1,9 @@
 import os
 import re
 
+from src.word_segmentation_rules_generator.preprocessing.preprocessor import (
+    adjust_spaces,
+)
 from src.word_segmentation_rules_generator.tagger.tagger import split_by_TSEK
 
 
@@ -37,7 +40,7 @@ def split_into_word_tag_list(tagged_file="TIB_test_maxmatched.txt.TAGGED"):
                 for i in range(len(syls_list)):
                     word_tag_list.append([syls_list[i], word_tag_splited[1][i]])
     word_tag_list = adjust_affix_with_tag(word_tag_list)
-    print(word_tag_list)
+    return word_tag_list
 
 
 def adjust_anomaly_tagged(syls_list, word_tag_splited):
@@ -74,3 +77,23 @@ def adjust_affix_with_tag(word_tag_list):
                 replacement = r" -\1"
                 word_tag_list[i][0] = re.sub(pattern, replacement, word_tag_list[i][0])
     return word_tag_list
+
+
+def split_merge_to_proper_string(tagged_file="TIB_test_maxmatched.txt.TAGGED"):
+    """
+    Input: tagged file, each word followed by \\ slash and tag predicted by rdr
+    Output: string that is joined according to the tag
+    """
+    word_tag_list = split_into_word_tag_list(tagged_file)
+    joined_string = ""
+    for i in range(len(word_tag_list)):
+        if word_tag_list[i][1] == "P":
+            joined_string += word_tag_list[i][0] + " "
+        else:
+            if word_tag_list[i][1] in ["A", "N"]:
+                joined_string += " "
+            joined_string += word_tag_list[i][0]
+            if word_tag_list[i + 1][1] in ["A", "N", "P"]:
+                joined_string += " "
+    joined_string = adjust_spaces(joined_string)
+    return joined_string

--- a/src/word_segmentation_rules_generator/rdr_2_cql/split_merge_syls.py
+++ b/src/word_segmentation_rules_generator/rdr_2_cql/split_merge_syls.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from src.word_segmentation_rules_generator.tagger.tagger import split_by_TSEK
 
@@ -23,6 +24,10 @@ def split_merge_syls(tagged_file="TIB_train_maxmatched.txt.TAGGED"):
             break
         word_tag_splited = word.split("/")
         if word_tag_splited[1] == "P":
+            # If there is an affix involved,then there needs to be a space
+            pattern = "-"
+            replacement = " -"
+            word_tag_splited[0] = re.sub(pattern, replacement, word_tag_splited[0])
             word_tag_list.append(word_tag_splited)
         else:
             syls_list = split_by_TSEK(word_tag_splited[0])

--- a/src/word_segmentation_rules_generator/rdr_2_cql/split_merge_syls.py
+++ b/src/word_segmentation_rules_generator/rdr_2_cql/split_merge_syls.py
@@ -4,7 +4,7 @@ import re
 from src.word_segmentation_rules_generator.tagger.tagger import split_by_TSEK
 
 
-def split_merge_syls(tagged_file="TIB_train_maxmatched.txt.TAGGED"):
+def split_into_word_tag_list(tagged_file="TIB_test_maxmatched.txt.TAGGED"):
     """
     Input: file that is tagged by rdr rules
     Output:
@@ -17,11 +17,7 @@ def split_merge_syls(tagged_file="TIB_train_maxmatched.txt.TAGGED"):
     contents = file.read()
     words_list = contents.split()
     word_tag_list = []
-    counter = 0
     for word in words_list:
-        counter += 1
-        if counter > 100:
-            break
         word_tag_splited = word.split("/")
         if word_tag_splited[1] == "P":
             # If there is an affix involved,then there needs to be a space
@@ -31,10 +27,44 @@ def split_merge_syls(tagged_file="TIB_train_maxmatched.txt.TAGGED"):
             word_tag_list.append(word_tag_splited)
         else:
             syls_list = split_by_TSEK(word_tag_splited[0])
+            # ['ལོག་པ-འོ', 'C'], in cases like here where there are two syllables in a word but only one tag
             if len(syls_list) != len(word_tag_splited[1]):
-                print(
-                    "Error in the resulted tagged file, number of syllables is not equal to number of tags."
+                anomaly_word_tag_list = adjust_anomaly_tagged(
+                    syls_list, word_tag_splited
                 )
-            for i in range(len(syls_list)):
-                word_tag_list.append([syls_list[i], word_tag_splited[1][i]])
+                word_tag_list = word_tag_list + anomaly_word_tag_list
+            else:
+                for i in range(len(syls_list)):
+                    word_tag_list.append([syls_list[i], word_tag_splited[1][i]])
+    word_tag_list = adjust_affix_with_tag(word_tag_list)
     print(word_tag_list)
+
+
+def adjust_anomaly_tagged(syls_list, word_tag_splited):
+    anomaly_word_tag_list = []
+    for i in range(len(syls_list)):
+        if i < len(word_tag_splited[1]):
+            anomaly_word_tag_list.append([syls_list[i], word_tag_splited[1][i]])
+        else:
+            anomaly_word_tag_list.append([syls_list[i], "C"])
+    return anomaly_word_tag_list
+
+
+def adjust_affix_with_tag(word_tag_list):
+    for i in range(len(word_tag_list)):
+        if word_tag_list[i][1] in ["P", "N", "C"]:
+            # If there is an affix involved,then there needs to be a space
+            pattern = "-"
+            replacement = " -"
+            word_tag_list[i][0] = re.sub(pattern, replacement, word_tag_list[i][0])
+        else:  # So the tag is eithe A or B
+            pattern = "-"
+            replacement = " -"
+            match = re.search(pattern, word_tag_list[i][0])
+            if match:
+                word_tag_list[i][0] = re.sub(pattern, replacement, word_tag_list[i][0])
+            else:
+                pattern = r"(ར|ས|འི|འམ|འང|འོ|འིའོ|འིའམ|འིའང|འོའམ|འོའང)"
+                replacement = r" -\1"
+                word_tag_list[i][0] = re.sub(pattern, replacement, word_tag_list[i][0])
+    return word_tag_list

--- a/src/word_segmentation_rules_generator/rdr_2_cql/split_merge_syls.py
+++ b/src/word_segmentation_rules_generator/rdr_2_cql/split_merge_syls.py
@@ -1,0 +1,21 @@
+import os
+
+
+def split_merge_syls(tagged_file="TIB_train_maxmatched.txt.TAGGED"):
+    """
+    Input: file that is tagged by rdr rules
+    Output:
+    """
+    current_dir = os.path.dirname(__file__)
+    relative_path = "../data/" + tagged_file
+    file_path = os.path.join(current_dir, relative_path)
+
+    file = open(file_path, encoding="utf-8")
+    contents = file.read()
+    words_list = contents.split()
+    word_tag_list = []
+    for word in words_list:
+        word_tag_splited = word.split("/")
+        word_tag_list.append(word_tag_splited)
+
+    print(word_tag_list)

--- a/src/word_segmentation_rules_generator/rdr_2_cql/split_merge_syls.py
+++ b/src/word_segmentation_rules_generator/rdr_2_cql/split_merge_syls.py
@@ -7,7 +7,7 @@ from src.word_segmentation_rules_generator.tagger.tagger import split_by_TSEK
 def split_into_word_tag_list(tagged_file="TIB_test_maxmatched.txt.TAGGED"):
     """
     Input: file that is tagged by rdr rules
-    Output:
+    Output:List with word or syllables with their associated tag (P,A,B,N,C)
     """
     current_dir = os.path.dirname(__file__)
     relative_path = "../data/" + tagged_file
@@ -41,6 +41,12 @@ def split_into_word_tag_list(tagged_file="TIB_test_maxmatched.txt.TAGGED"):
 
 
 def adjust_anomaly_tagged(syls_list, word_tag_splited):
+    """
+    In some cases, for words that are not perfectly tagged, RDR is not tagging the same number
+    as the syllables as its supposed to i.e, ['ལོག་པ-འོ', 'C'],
+    Input: ['ལོག་པ-འོ', 'C']
+    Output: ['ལོག་', 'C','པ-འོ','C']
+    """
     anomaly_word_tag_list = []
     for i in range(len(syls_list)):
         if i < len(word_tag_splited[1]):
@@ -57,7 +63,7 @@ def adjust_affix_with_tag(word_tag_list):
             pattern = "-"
             replacement = " -"
             word_tag_list[i][0] = re.sub(pattern, replacement, word_tag_list[i][0])
-        else:  # So the tag is eithe A or B
+        else:  # So the tag is either A or B
             pattern = "-"
             replacement = " -"
             match = re.search(pattern, word_tag_list[i][0])

--- a/src/word_segmentation_rules_generator/rdr_2_cql/split_merge_syls.py
+++ b/src/word_segmentation_rules_generator/rdr_2_cql/split_merge_syls.py
@@ -1,5 +1,7 @@
 import os
 
+from src.word_segmentation_rules_generator.tagger.tagger import split_by_TSEK
+
 
 def split_merge_syls(tagged_file="TIB_train_maxmatched.txt.TAGGED"):
     """
@@ -14,8 +16,20 @@ def split_merge_syls(tagged_file="TIB_train_maxmatched.txt.TAGGED"):
     contents = file.read()
     words_list = contents.split()
     word_tag_list = []
+    counter = 0
     for word in words_list:
+        counter += 1
+        if counter > 100:
+            break
         word_tag_splited = word.split("/")
-        word_tag_list.append(word_tag_splited)
-
+        if word_tag_splited[1] == "P":
+            word_tag_list.append(word_tag_splited)
+        else:
+            syls_list = split_by_TSEK(word_tag_splited[0])
+            if len(syls_list) != len(word_tag_splited[1]):
+                print(
+                    "Error in the resulted tagged file, number of syllables is not equal to number of tags."
+                )
+            for i in range(len(syls_list)):
+                word_tag_list.append([syls_list[i], word_tag_splited[1][i]])
     print(word_tag_list)

--- a/tests/test_split_merge_syls.py
+++ b/tests/test_split_merge_syls.py
@@ -1,0 +1,16 @@
+from src.word_segmentation_rules_generator.rdr_2_cql.split_merge_syls import (
+    split_merge_to_proper_string,
+)
+
+
+def test_split_merge_syls():
+    """
+    Testing the function split_merge_to_proper_string
+    the file is tagged with rdr
+    and outputs the words in proper way
+    """
+    joined_string = split_merge_to_proper_string("TIB_short_test_maxmatched.txt.TAGGED")
+    assert (
+        joined_string
+        == "༄༅།_། སྐྱེས་པ -འི་ རབས་ ཀྱི་ རྒྱ་ ཆེ -ར་ བཤད་པ །_༄༅༅།_། རྒྱ་གར་ སྐད་ དུ །_ ཛཱ་ ཏ་ ཀ་ མཱ་ ལཱ་ ཊཱི་ ཀཱ །_ བོད་སྐད་དུ །_ སྐྱེས་པ -འི་ རབས་ ཀྱི་ རྒྱ་ ཆེ -ར་ བཤད་པ །_ བཅོམ་ལྡན་འདས་ ངག་ གི་ དབང་པོ་ ལ་ ཕྱག་འཚལ་ ལོ །_། ཐུབ་པ -འི་ ལེགས་ སྤྱོད་ རྨད་བྱུང་ དཔག་མེད་པ །_། སྙན་ངག་ མཁན་པོ་ འཕགས་པ་ དཔའ་བོ -ས་ བཀོད །_། བདག་ བློ་ ཞན་ ཀྱང་ གུས་པ -ས་ བཤད་པ་ ནི །_། བློ་ ཆུང་ དག་ ལ་ པན་ ཕྱིར་ རབ་ཏུ་ བརྩམས །_།"  # noqa
+    )


### PR DESCRIPTION
Replace for tag has already been completed before. 
Here in split and merge functions, function has been created that will do the split and merge words/syllables rather than adding it to cql rules.

Reason:>
There already cql rules for replace function such that for segmentation tags. i.e P, A, B, C, N
Eg: [text="མི་"] [word_tag="P"]	2	=	[word_tag="C"]
And in rdr rules (all in replace function),  most of the are written in generalized cases.

But in splitting cases, 
Lets take for example two different words but with same tagged NNC.(སྔོན་འགྲོ་བ་/NNC, གདུང་བྱེད་པ་/NNC)
 Now here there are 3 syllables and there supposed to split. i.e( སྔོན་ འགྲོ་བ་,  གདུང་ བྱེད་པ་)
 and if we want to include this in CQL rules, there will be two lines (if there are more words then more)in the format `<matchcql>\t<index>\t<operation>\t<replacecql>`.  for each of those words. (file could be really large sized)
[སྔོན་འགྲོ་བ་ & tag='NNC'] 5 : [སྔོན་] [འགྲོ་བ་]
[གདུང་བྱེད་པ་ & tag='NNC'] 5 : [གདུང་བྱེད་པ་] [གདུང་བྱེད་པ་]
We cant input just one line to generalized all the rules for tag "NNC' or any other tag for splitting and merging. Thats why i believe its way more resource effective to just split  and merge using the function.
For the word segmention, even if the rule file is large, it is necessity, but if the file would be large just for split and merge, i dont believe its the right  way to go.

